### PR TITLE
Migrate from utils to cliutils

### DIFF
--- a/os_virtual_interfacesv2_python_novaclient_ext.py
+++ b/os_virtual_interfacesv2_python_novaclient_ext.py
@@ -15,6 +15,11 @@
 from novaclient import base
 from novaclient import utils
 
+try:
+    from novaclient.openstack.common import cliutils
+except ImportError:
+    cliutils = utils
+
 
 class VirtualInterface(base.Resource):
     def create(self):
@@ -52,7 +57,7 @@ def ip_address_formatter(field):
     return ",".join(addresses)
 
 
-@utils.arg('instance_id', metavar='<instance_id>',
+@cliutils.arg('instance_id', metavar='<instance_id>',
            help="ID of the instance you want to display virtual"
                 "interfaces for")
 def do_virtual_interface_list(cs, args):
@@ -65,9 +70,9 @@ def do_virtual_interface_list(cs, args):
                      formatters={"ip_addresses": ip_address_formatter})
 
 
-@utils.arg('network_id', metavar='<network_id>',
+@cliutils.arg('network_id', metavar='<network_id>',
            help='Network ID to connect the new virtual interface to')
-@utils.arg('instance_id', metavar='<instance_id>',
+@cliutils.arg('instance_id', metavar='<instance_id>',
            help="Instance to attach the new virtual interface to")
 def do_virtual_interface_create(cs, args):
     """
@@ -84,9 +89,9 @@ def do_virtual_interface_create(cs, args):
         utils.print_dict(addr_dict)
 
 
-@utils.arg('instance_id', metavar='<instance_id>',
+@cliutils.arg('instance_id', metavar='<instance_id>',
            help="Instance to remove the virtual interface from")
-@utils.arg('interface_id', metavar='<interface_id>',
+@cliutils.arg('interface_id', metavar='<interface_id>',
            help='ID of the virtual interface to delete')
 def do_virtual_interface_delete(cs, args):
     """


### PR DESCRIPTION
Novaclient migrated from its utils to openstack's cliutils for some
things a year ago (commit id 871c5fc1) and recently removed the
aliases from utils (commit id 96a124fa) causing AttributeError
exceptions, so follow novaclient's example and migrate from utils to
cliutils where applicable.

Just in case someone is using this with a year older novaclient
release, if importing cliutils fails, then alias it to utils.